### PR TITLE
Moved database logic from MemberService

### DIFF
--- a/src/main/scala/bookbot/Main.scala
+++ b/src/main/scala/bookbot/Main.scala
@@ -1,6 +1,6 @@
 package bookbot
 
-import bookbot.repository.BookRepositoryLive
+import bookbot.repository.{BookRepositoryLive, MemberRepositoryLive}
 import bookbot.server.CommandsBot
 import bookbot.service.{BookServiceLive, MemberServiceLive}
 import com.typesafe.config.ConfigFactory
@@ -24,6 +24,7 @@ object Main extends zio.ZIOAppDefault {
           BookServiceLive.layer,
           MemberServiceLive.layer,
           BookRepositoryLive.layer,
+          MemberRepositoryLive.layer,
           QuillContext.dataSourceLayer
         )
     } yield ()

--- a/src/main/scala/bookbot/repository/MemberRepository.scala
+++ b/src/main/scala/bookbot/repository/MemberRepository.scala
@@ -1,0 +1,12 @@
+package bookbot.repository
+
+import bookbot.model.Member
+import zio.Task
+
+trait MemberRepository {
+
+  def getByTelegramId(telegramId: Long): Task[Option[Member]]
+
+  def create(memberTelegramId: Long): Task[Member]
+
+}

--- a/src/main/scala/bookbot/repository/MemberRepositoryLive.scala
+++ b/src/main/scala/bookbot/repository/MemberRepositoryLive.scala
@@ -1,0 +1,33 @@
+package bookbot.repository
+
+import bookbot.model.Member
+import zio.{Task, ZEnvironment, ZLayer}
+
+import javax.sql.DataSource
+
+final case class MemberRepositoryLive(
+                                       dataSource: DataSource
+                                     ) extends MemberRepository {
+
+  import bookbot.QuillContext._
+
+  override def getByTelegramId(telegramId: Long): Task[Option[Member]] =
+    run(query[Member].filter(_.telegramId == lift(telegramId)))
+      .provideEnvironment(ZEnvironment(dataSource))
+      .map(_.headOption)
+
+
+  override def create(memberTelegramId: Long): Task[Member] =
+    for {
+      member <- Member.make(memberTelegramId)
+      _ <- run(query[Member].insertValue(lift(member))).provideEnvironment(ZEnvironment(dataSource))
+    } yield member
+
+}
+
+object MemberRepositoryLive {
+
+  val layer: ZLayer[DataSource, Nothing, MemberRepository] = ZLayer.fromFunction(MemberRepositoryLive.apply _)
+
+
+}

--- a/src/main/scala/bookbot/service/BookServiceLive.scala
+++ b/src/main/scala/bookbot/service/BookServiceLive.scala
@@ -15,11 +15,7 @@ final case class BookServiceLive(
 
   override def create(memberTelegramId: Long, title: String, author: String, startDateInEpochSeconds: Int): Task[Book] =
     for {
-      memberOptional <- memberService.getByTelegramId(memberTelegramId)
-      member <- memberOptional match {
-        case Some(value) => ZIO.attempt(value)
-        case None => memberService.create(memberTelegramId)
-      }
+      member <- memberService.getByTelegramId(memberTelegramId)
       startDate <- toLocalDate(startDateInEpochSeconds)
       book <- bookRepository.create(member.id, title, author, startDate)
     } yield book

--- a/src/main/scala/bookbot/service/MemberService.scala
+++ b/src/main/scala/bookbot/service/MemberService.scala
@@ -5,7 +5,7 @@ import zio.Task
 
 trait MemberService {
 
-  def getByTelegramId(telegramId: Long): Task[Option[Member]]
+  def getByTelegramId(telegramId: Long): Task[Member]
 
   def create(memberTelegramId: Long): Task[Member]
 


### PR DESCRIPTION
Closes #2 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `MemberRepository` and `MemberService` implementations. 

### Detailed summary
- Updated `MemberService` interface to return a `Member` instead of an `Option[Member]` when getting by telegram ID.
- Added `MemberRepository` trait with methods to get by telegram ID and create a member.
- Implemented `MemberRepositoryLive` with Quill queries to get by telegram ID and create a member.
- Updated `MemberServiceLive` implementation to use the `MemberRepository` for getting by telegram ID and creating a member.
- Added `MemberRepositoryLive` and `MemberServiceLive` to the `Main` object's ZLayer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->