### PR TITLE
Considered the moment of member creation

### DIFF
--- a/src/main/scala/bookbot/service/BookServiceLive.scala
+++ b/src/main/scala/bookbot/service/BookServiceLive.scala
@@ -15,7 +15,7 @@ final case class BookServiceLive(
 
   override def create(memberTelegramId: Long, title: String, author: String, startDateInEpochSeconds: Int): Task[Book] =
     for {
-      member <- memberService.getByTelegramId(memberTelegramId)
+      member <- memberService.getOrCreate(memberTelegramId)
       startDate <- toLocalDate(startDateInEpochSeconds)
       book <- bookRepository.create(member.id, title, author, startDate)
     } yield book

--- a/src/main/scala/bookbot/service/MemberService.scala
+++ b/src/main/scala/bookbot/service/MemberService.scala
@@ -7,6 +7,6 @@ trait MemberService {
 
   def getOrCreate(telegramId: Long): Task[Member]
 
-  def create(memberTelegramId: Long): Task[Member]
+  def create(telegramId: Long): Task[Member]
 
 }

--- a/src/main/scala/bookbot/service/MemberService.scala
+++ b/src/main/scala/bookbot/service/MemberService.scala
@@ -5,7 +5,7 @@ import zio.Task
 
 trait MemberService {
 
-  def getByTelegramId(telegramId: Long): Task[Member]
+  def getOrCreate(telegramId: Long): Task[Member]
 
   def create(memberTelegramId: Long): Task[Member]
 

--- a/src/main/scala/bookbot/service/MemberServiceLive.scala
+++ b/src/main/scala/bookbot/service/MemberServiceLive.scala
@@ -10,12 +10,12 @@ final case class MemberServiceLive(
                                   ) extends MemberService {
 
 
-  override def getByTelegramId(telegramId: Long): Task[Member] =
+  override def getOrCreate(telegramId: Long): Task[Member] =
     for {
       memberOpt <- repository.getByTelegramId(telegramId)
       member <- memberOpt match {
         case Some(member) => ZIO.succeed(member)
-        case None => ZIO.die(new RuntimeException("Member not found!")) //todo
+        case None => repository.create(telegramId)
       }
     } yield member
 

--- a/src/main/scala/bookbot/service/MemberServiceLive.scala
+++ b/src/main/scala/bookbot/service/MemberServiceLive.scala
@@ -19,8 +19,8 @@ final case class MemberServiceLive(
       }
     } yield member
 
-  override def create(memberTelegramId: Long): Task[Member] =
-    repository.create(memberTelegramId)
+  override def create(telegramId: Long): Task[Member] =
+    repository.create(telegramId)
 
 }
 


### PR DESCRIPTION
Closes #5 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the MemberService and BookServiceLive classes. 

### Detailed summary
- Renamed the `getByTelegramId` method in `MemberService` to `getOrCreate` and updated its implementation.
- Renamed the `create` method in `MemberService` to `create` and updated its implementation.
- Updated the `create` method in `BookServiceLive` to use the `getOrCreate` method from `MemberService` instead of `getByTelegramId`.
- Updated the implementation of `getOrCreate` and `create` methods in `MemberServiceLive` to use the new parameter names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->